### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/garden.jamie.Morphosis.json
+++ b/garden.jamie.Morphosis.json
@@ -11,15 +11,7 @@
     "--socket=wayland"
   ],
   "cleanup": [
-    "/include",
-    "/lib/pkgconfig",
-    "/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/share/man",
-    "/share/pkgconfig",
-    "*.la",
-    "*.a"
+    "/share/man"
   ],
   "modules": [
     {


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.